### PR TITLE
Remove from !important text-dark/light

### DIFF
--- a/src/styles/users-label.scss
+++ b/src/styles/users-label.scss
@@ -8,11 +8,11 @@
 }
 
 .text-light {
-  color: #000 !important;
+  color: #000;
 }
 
 .text-dark {
-  color: #fff !important;
+  color: #fff;
 }
 
 .label-edit-box {


### PR DESCRIPTION
I made sure to test if everything worked fine without the `!important` and it looks fine.

Closes #9